### PR TITLE
Removing state that ties a ChargePoint instance to a specific connected CP

### DIFF
--- a/ocpp/async_message_handler.py
+++ b/ocpp/async_message_handler.py
@@ -1,0 +1,12 @@
+from abc import ABC
+from abc import abstractmethod
+
+
+class AsyncMessageHandler(ABC):
+    @abstractmethod
+    async def handle(self, connection_uid: str, message: str) -> None:
+        """
+        Handle the given message (which can be for a specific connection, if a
+        single handler is used to handle messages to multiple connections).
+        """
+        pass

--- a/tests/test_charge_point.py
+++ b/tests/test_charge_point.py
@@ -395,14 +395,14 @@ async def test_call_unique_id_added_to_handler_args_correctly(connection):
         action=Action.BootNotification.value,
         payload=payload_a,
     )
-    await charger_a._handle_call(msg_a)
+    await charger_a._handle_message(msg_a)
 
     msg_b = Call(
         unique_id=charger_b_test_call_unique_id,
         action=Action.BootNotification.value,
         payload=payload_b,
     )
-    await charger_b._handle_call(msg_b)
+    await charger_b._handle_message(msg_b)
 
     assert ChargerA.on_boot_notification_call_count == 1
     assert ChargerA.after_boot_notification_call_count == 1


### PR DESCRIPTION
We want to be able to use the message parsing/creation and the @on annotations of the ocpp library, but we don't want to have ChargePoint objects tied to a specific connection - we want them to be stateless and able to handle messages for any connected CPs in a parallel architecture.